### PR TITLE
Refactor AI generation into shared services

### DIFF
--- a/docucraft-worker/package.json
+++ b/docucraft-worker/package.json
@@ -6,7 +6,8 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
     "start": "wrangler dev",
-    "cf-typegen": "wrangler types"
+    "cf-typegen": "wrangler types",
+    "test": "bun test"
   },
   "dependencies": {
     "@google/genai": "^1.10.0",

--- a/docucraft-worker/src/endpoints/aiCreate.ts
+++ b/docucraft-worker/src/endpoints/aiCreate.ts
@@ -1,9 +1,9 @@
 import { Bool, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { AIRequest, AIResponse, AppContext } from "../types";
-import { GoogleGenAI } from "@google/genai";
 import { env } from "hono/adapter";
-import { prompt } from "../../prompts/mvp";
+import { generateAIContent } from "../services/aiGenerationService";
+import { formatDiagramResponse } from "../services/aiResponseFormatter";
 
 type Env = {
   GOOGLE_AI_STUDIO_TOKEN: string;
@@ -49,64 +49,14 @@ export class AiCreate extends OpenAPIRoute {
     const aiRequest = data.body;
     const { GOOGLE_AI_STUDIO_TOKEN } = env(c) as Env;
 
-    // Get current date for Gantt chart
-    const currentDate = new Date().toISOString().split("T")[0]; // YYYY-MM-DD format
-    const ai = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_TOKEN,
-    });
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash-lite",
-      contents: `
-${prompt}
-
-${aiRequest.text}`,
-    });
-
-    let text = response.text;
-
-    // Clean the response if it contains markdown formatting
-    if (text.includes("```json") || text.includes("```")) {
-      // Remove markdown code blocks
-      text = text.replace(/```json\s*/g, "").replace(/```\s*/g, "");
-      // Trim any leading/trailing whitespace
-      text = text.trim();
-    }
-
-    // Clean escaped JSON if the response contains escaped characters
-    if (text.includes("\\n") || text.includes('\\"')) {
-      try {
-        // Parse the escaped JSON string to get the actual JSON
-        const parsedText = JSON.parse(text);
-        text = JSON.stringify(parsedText);
-      } catch (error) {
-        // If parsing fails, try to clean common escape sequences
-        text = text
-          .replace(/\\n/g, "\n")
-          .replace(/\\"/g, '"')
-          .replace(/\\\\/g, "\\");
-      }
-    }
-
-    // Additional JSON safety check - ensure proper escaping
-    try {
-      // Test if the text can be parsed as JSON
-      JSON.parse(text);
-    } catch (error) {
-      console.error("JSON parsing failed after cleaning:", error);
-      // If still failing, try to fix common JSON issues
-      text = text
-        .replace(/\n/g, "\\n")
-        .replace(/"/g, '\\"')
-        .replace(/\\/g, "\\\\");
-    }
-
-    console.log(text);
+    const rawText = await generateAIContent("mvp", aiRequest, GOOGLE_AI_STUDIO_TOKEN);
+    const formatted = formatDiagramResponse("json", rawText);
 
     return new Response(
       JSON.stringify({
         success: true,
         aiResponse: {
-          text: JSON.parse(text),
+          text: JSON.parse(formatted),
         },
       }),
       {

--- a/docucraft-worker/src/endpoints/aiCreateArchitecture.ts
+++ b/docucraft-worker/src/endpoints/aiCreateArchitecture.ts
@@ -1,9 +1,9 @@
 import { Bool, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { AIRequest, AIResponse, AppContext } from "../types";
-import { GoogleGenAI } from "@google/genai";
 import { env } from "hono/adapter";
-import { prompt } from "../../prompts/architecture";
+import { generateAIContent } from "../services/aiGenerationService";
+import { formatDiagramResponse } from "../services/aiResponseFormatter";
 
 type Env = {
   GOOGLE_AI_STUDIO_TOKEN: string;
@@ -49,34 +49,18 @@ export class AiCreateArchitecture extends OpenAPIRoute {
     const aiRequest = data.body;
     const { GOOGLE_AI_STUDIO_TOKEN } = env(c) as Env;
 
-    const ai = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_TOKEN,
-    });
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash-lite",
-      contents: `
-${prompt}
-
-${aiRequest.text}`,
-    });
-
-    let text = response.text;
-
-    // Clean the response if it contains markdown formatting
-    if (text.includes("```mermaid") || text.includes("```")) {
-      // Remove markdown code blocks
-      text = text.replace(/```mermaid\s*/g, "").replace(/```\s*/g, "");
-      // Trim any leading/trailing whitespace
-      text = text.trim();
-    }
-
-    console.log(text);
+    const rawText = await generateAIContent(
+      "architecture",
+      aiRequest,
+      GOOGLE_AI_STUDIO_TOKEN,
+    );
+    const formatted = formatDiagramResponse("mermaid", rawText);
 
     return new Response(
       JSON.stringify({
         success: true,
         aiResponse: {
-          text: text,
+          text: formatted,
         },
       }),
       {

--- a/docucraft-worker/src/endpoints/aiCreateC4.ts
+++ b/docucraft-worker/src/endpoints/aiCreateC4.ts
@@ -1,9 +1,9 @@
 import { Bool, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { AIRequest, AIResponse, AppContext } from "../types";
-import { GoogleGenAI } from "@google/genai";
 import { env } from "hono/adapter";
-import { prompt } from "../../prompts/c4";
+import { generateAIContent } from "../services/aiGenerationService";
+import { formatDiagramResponse } from "../services/aiResponseFormatter";
 
 type Env = {
   GOOGLE_AI_STUDIO_TOKEN: string;
@@ -49,34 +49,14 @@ export class AiCreateC4 extends OpenAPIRoute {
     const aiRequest = data.body;
     const { GOOGLE_AI_STUDIO_TOKEN } = env(c) as Env;
 
-    const ai = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_TOKEN,
-    });
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash-lite",
-      contents: `
-${prompt}
-
-${aiRequest.text}`,
-    });
-
-    let text = response.text;
-
-    // Clean the response if it contains markdown formatting
-    if (text.includes("```mermaid") || text.includes("```")) {
-      // Remove markdown code blocks
-      text = text.replace(/```mermaid\s*/g, "").replace(/```\s*/g, "");
-      // Trim any leading/trailing whitespace
-      text = text.trim();
-    }
-
-    console.log(text);
+    const rawText = await generateAIContent("c4", aiRequest, GOOGLE_AI_STUDIO_TOKEN);
+    const formatted = formatDiagramResponse("mermaid", rawText);
 
     return new Response(
       JSON.stringify({
         success: true,
         aiResponse: {
-          text: text,
+          text: formatted,
         },
       }),
       {

--- a/docucraft-worker/src/endpoints/aiCreateERD.ts
+++ b/docucraft-worker/src/endpoints/aiCreateERD.ts
@@ -1,9 +1,9 @@
 import { Bool, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { AIRequest, AIResponse, AppContext } from "../types";
-import { GoogleGenAI } from "@google/genai";
 import { env } from "hono/adapter";
-import { prompt } from "../../prompts/erd";
+import { generateAIContent } from "../services/aiGenerationService";
+import { formatDiagramResponse } from "../services/aiResponseFormatter";
 
 type Env = {
   GOOGLE_AI_STUDIO_TOKEN: string;
@@ -49,32 +49,14 @@ export class AiCreateERD extends OpenAPIRoute {
     const aiRequest = data.body;
     const { GOOGLE_AI_STUDIO_TOKEN } = env(c) as Env;
 
-    const ai = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_TOKEN,
-    });
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash-lite",
-      contents: `
-${prompt}
-
-${aiRequest.text}`,
-    });
-
-    let text = response.text;
-
-    // Clean the response if it contains markdown formatting
-    if (text.includes("```mermaid") || text.includes("```")) {
-      // Remove markdown code blocks
-      text = text.replace(/```mermaid\s*/g, "").replace(/```\s*/g, "");
-      // Trim any leading/trailing whitespace
-      text = text.trim();
-    }
+    const rawText = await generateAIContent("erd", aiRequest, GOOGLE_AI_STUDIO_TOKEN);
+    const formatted = formatDiagramResponse("mermaid", rawText);
 
     return new Response(
       JSON.stringify({
         success: true,
         aiResponse: {
-          text: text,
+          text: formatted,
         },
       }),
       {

--- a/docucraft-worker/src/endpoints/aiCreateGantt.ts
+++ b/docucraft-worker/src/endpoints/aiCreateGantt.ts
@@ -1,9 +1,9 @@
 import { Bool, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { AIRequest, AIResponse, AppContext } from "../types";
-import { GoogleGenAI } from "@google/genai";
 import { env } from "hono/adapter";
-import { prompt } from "../../prompts/gantt";
+import { generateAIContent } from "../services/aiGenerationService";
+import { formatDiagramResponse } from "../services/aiResponseFormatter";
 
 type Env = {
   GOOGLE_AI_STUDIO_TOKEN: string;
@@ -49,36 +49,14 @@ export class AiCreateGantt extends OpenAPIRoute {
     const aiRequest = data.body;
     const { GOOGLE_AI_STUDIO_TOKEN } = env(c) as Env;
 
-    // Get current date for Gantt chart
-    const currentDate = new Date().toISOString().split("T")[0]; // YYYY-MM-DD format
-    const ai = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_TOKEN,
-    });
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash-lite",
-      contents: `
-${prompt}
-
-${aiRequest.text}`,
-    });
-
-    let text = response.text;
-
-    // Clean the response if it contains markdown formatting
-    if (text.includes("```mermaid") || text.includes("```")) {
-      // Remove markdown code blocks
-      text = text.replace(/```mermaid\s*/g, "").replace(/```\s*/g, "");
-      // Trim any leading/trailing whitespace
-      text = text.trim();
-    }
-
-    console.log(text);
+    const rawText = await generateAIContent("gantt", aiRequest, GOOGLE_AI_STUDIO_TOKEN);
+    const formatted = formatDiagramResponse("mermaid", rawText);
 
     return new Response(
       JSON.stringify({
         success: true,
         aiResponse: {
-          text: text,
+          text: formatted,
         },
       }),
       {

--- a/docucraft-worker/src/endpoints/aiCreateKanban.ts
+++ b/docucraft-worker/src/endpoints/aiCreateKanban.ts
@@ -1,9 +1,9 @@
 import { Bool, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { AIRequest, AIResponse, AppContext } from "../types";
-import { GoogleGenAI } from "@google/genai";
 import { env } from "hono/adapter";
-import { prompt } from "../../prompts/kanban";
+import { generateAIContent } from "../services/aiGenerationService";
+import { formatDiagramResponse } from "../services/aiResponseFormatter";
 
 type Env = {
   GOOGLE_AI_STUDIO_TOKEN: string;
@@ -49,34 +49,14 @@ export class AiCreateKanban extends OpenAPIRoute {
     const aiRequest = data.body;
     const { GOOGLE_AI_STUDIO_TOKEN } = env(c) as Env;
 
-    const ai = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_TOKEN,
-    });
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash-lite",
-      contents: `
-${prompt}
-
-${aiRequest.text}`,
-    });
-
-    let text = response.text;
-
-    // Clean the response if it contains markdown formatting
-    if (text.includes("```mermaid") || text.includes("```")) {
-      // Remove markdown code blocks
-      text = text.replace(/```mermaid\s*/g, "").replace(/```\s*/g, "");
-      // Trim any leading/trailing whitespace
-      text = text.trim();
-    }
-
-    console.log(text);
+    const rawText = await generateAIContent("kanban", aiRequest, GOOGLE_AI_STUDIO_TOKEN);
+    const formatted = formatDiagramResponse("mermaid", rawText);
 
     return new Response(
       JSON.stringify({
         success: true,
         aiResponse: {
-          text: text,
+          text: formatted,
         },
       }),
       {

--- a/docucraft-worker/src/endpoints/aiCreateUserStories.ts
+++ b/docucraft-worker/src/endpoints/aiCreateUserStories.ts
@@ -1,9 +1,9 @@
 import { Bool, OpenAPIRoute } from "chanfana";
 import { z } from "zod";
 import { AIRequest, AIResponse, AppContext } from "../types";
-import { GoogleGenAI } from "@google/genai";
 import { env } from "hono/adapter";
-import { prompt } from "../../prompts/user-stories";
+import { generateAIContent } from "../services/aiGenerationService";
+import { formatDiagramResponse } from "../services/aiResponseFormatter";
 
 type Env = {
   GOOGLE_AI_STUDIO_TOKEN: string;
@@ -49,62 +49,18 @@ export class AiCreateUserStories extends OpenAPIRoute {
     const aiRequest = data.body;
     const { GOOGLE_AI_STUDIO_TOKEN } = env(c) as Env;
 
-    const ai = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_TOKEN,
-    });
-    const response = await ai.models.generateContent({
-      model: "gemini-2.5-flash-lite",
-      contents: `
-${prompt}
-
-${aiRequest.text}`,
-    });
-
-    let text = response.text;
-
-    // Clean the response if it contains markdown formatting
-    if (text.includes("```json") || text.includes("```")) {
-      // Remove markdown code blocks
-      text = text.replace(/```json\s*/g, "").replace(/```\s*/g, "");
-      // Trim any leading/trailing whitespace
-      text = text.trim();
-    }
-
-    // Clean escaped JSON if the response contains escaped characters
-    if (text.includes("\\n") || text.includes('\\"')) {
-      try {
-        // Parse the escaped JSON string to get the actual JSON
-        const parsedText = JSON.parse(text);
-        text = JSON.stringify(parsedText);
-      } catch (error) {
-        // If parsing fails, try to clean common escape sequences
-        text = text
-          .replace(/\\n/g, "\n")
-          .replace(/\\"/g, '"')
-          .replace(/\\\\/g, "\\");
-      }
-    }
-
-    // Additional JSON safety check - ensure proper escaping
-    try {
-      // Test if the text can be parsed as JSON
-      JSON.parse(text);
-    } catch (error) {
-      console.error("JSON parsing failed after cleaning:", error);
-      // If still failing, try to fix common JSON issues
-      text = text
-        .replace(/\n/g, "\\n")
-        .replace(/"/g, '\\"')
-        .replace(/\\/g, "\\\\");
-    }
-
-    console.log(text);
+    const rawText = await generateAIContent(
+      "user-stories",
+      aiRequest,
+      GOOGLE_AI_STUDIO_TOKEN,
+    );
+    const formatted = formatDiagramResponse("json", rawText);
 
     return new Response(
       JSON.stringify({
         success: true,
         aiResponse: {
-          text: JSON.parse(text),
+          text: JSON.parse(formatted),
         },
       }),
       {

--- a/docucraft-worker/src/services/__tests__/aiGenerationService.test.ts
+++ b/docucraft-worker/src/services/__tests__/aiGenerationService.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import {
+  PROMPT_CONFIG,
+  generateAIContent,
+  getPromptFormat,
+  isPromptKey,
+  type ClientFactory,
+} from "../aiGenerationService";
+
+describe("aiGenerationService", () => {
+  it("generates content using the configured prompt", async () => {
+    const recordedRequests: Array<{ model: string; contents: string }> = [];
+    let recordedApiKey: string | null = null;
+
+    const factory: ClientFactory = (apiKey) => {
+      recordedApiKey = apiKey;
+      return {
+        models: {
+          generateContent: async (request) => {
+            recordedRequests.push(request);
+            return { text: "raw-response" };
+          },
+        },
+      };
+    };
+
+    const result = await generateAIContent(
+      "mvp",
+      { text: "Build an app" },
+      "test-key",
+      factory,
+    );
+
+    expect(result).toBe("raw-response");
+    expect(recordedApiKey).toBe("test-key");
+    expect(recordedRequests.length).toBe(1);
+    expect(recordedRequests[0]?.model).toBe("gemini-2.5-flash-lite");
+    expect(recordedRequests[0]?.contents).toContain(PROMPT_CONFIG.mvp.prompt);
+    expect(recordedRequests[0]?.contents).toContain("Build an app");
+  });
+
+  it("throws when the prompt key is unknown", async () => {
+    try {
+      await generateAIContent(
+        "unknown" as unknown as keyof typeof PROMPT_CONFIG,
+        { text: "Test" },
+        "key",
+      );
+      throw new Error("Expected to throw for unknown prompt key");
+    } catch (error) {
+      expect((error as Error).message).toBe("Unknown prompt key: unknown");
+    }
+  });
+
+  it("throws when the AI response is empty", async () => {
+    const factory: ClientFactory = () => ({
+      models: {
+        generateContent: async () => ({ text: "   " }),
+      },
+    });
+
+    try {
+      await generateAIContent("mvp", { text: "Build" }, "test-key", factory);
+      throw new Error("Expected to throw for empty AI response");
+    } catch (error) {
+      expect((error as Error).message).toBe("AI response did not include text output");
+    }
+  });
+
+  it("exposes helper utilities for prompt metadata", () => {
+    expect(getPromptFormat("mvp")).toBe("json");
+    expect(getPromptFormat("architecture")).toBe("mermaid");
+    expect(isPromptKey("kanban")).toBe(true);
+    expect(isPromptKey("not-real")).toBe(false);
+  });
+});

--- a/docucraft-worker/src/services/__tests__/aiResponseFormatter.test.ts
+++ b/docucraft-worker/src/services/__tests__/aiResponseFormatter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatDiagramResponse,
+  formatJsonResponse,
+  formatMermaidResponse,
+} from "../aiResponseFormatter";
+
+describe("aiResponseFormatter", () => {
+  it("strips mermaid code fences", () => {
+    const input = "```mermaid\ngraph TD;\nA-->B\n```";
+    expect(formatMermaidResponse(input)).toBe("graph TD;\nA-->B");
+  });
+
+  it("normalizes JSON content inside code fences", () => {
+    const input = "```json\n{\"name\":\"DocuCraft\"}\n```";
+    expect(formatJsonResponse(input)).toBe('{"name":"DocuCraft"}');
+  });
+
+  it("cleans escaped JSON payloads", () => {
+    const input = '{"name":"DocuCraft","details":"Line1\\nLine2"}';
+    expect(formatJsonResponse(input)).toBe(
+      '{"name":"DocuCraft","details":"Line1\\nLine2"}',
+    );
+  });
+
+  it("throws when JSON cannot be normalized", () => {
+    expect(() => formatJsonResponse("not-json")).toThrow(
+      "Unable to normalize AI JSON response",
+    );
+  });
+
+  it("delegates formatting based on diagram type", () => {
+    const mermaid = formatDiagramResponse(
+      "mermaid",
+      "```mermaid\nsequenceDiagram\nA->>B: Hi\n```",
+    );
+    const json = formatDiagramResponse(
+      "json",
+      "```json\n{\"ok\":true}\n```",
+    );
+
+    expect(mermaid).toBe("sequenceDiagram\nA->>B: Hi");
+    expect(json).toBe('{"ok":true}');
+  });
+});

--- a/docucraft-worker/src/services/aiGenerationService.ts
+++ b/docucraft-worker/src/services/aiGenerationService.ts
@@ -1,0 +1,86 @@
+import { GoogleGenAI } from "@google/genai";
+import type { AIRequestPayload } from "../types";
+import { prompt as architecturePrompt } from "../../prompts/architecture";
+import { prompt as c4Prompt } from "../../prompts/c4";
+import { prompt as erdPrompt } from "../../prompts/erd";
+import { prompt as ganttPrompt } from "../../prompts/gantt";
+import { prompt as kanbanPrompt } from "../../prompts/kanban";
+import { prompt as mvpPrompt } from "../../prompts/mvp";
+import { prompt as userStoriesPrompt } from "../../prompts/user-stories";
+import type { DiagramFormat } from "./aiResponseFormatter";
+
+export const MODEL_NAME = "gemini-2.5-flash-lite";
+
+type PromptConfiguration = {
+  prompt: string;
+  format: DiagramFormat;
+};
+
+export const PROMPT_CONFIG: Record<PromptKey, PromptConfiguration> = {
+  mvp: { prompt: mvpPrompt, format: "json" },
+  architecture: { prompt: architecturePrompt, format: "mermaid" },
+  c4: { prompt: c4Prompt, format: "mermaid" },
+  erd: { prompt: erdPrompt, format: "mermaid" },
+  gantt: { prompt: ganttPrompt, format: "mermaid" },
+  kanban: { prompt: kanbanPrompt, format: "mermaid" },
+  "user-stories": { prompt: userStoriesPrompt, format: "json" },
+};
+
+export type PromptKey = keyof typeof PROMPT_CONFIG;
+
+export function isPromptKey(value: string): value is PromptKey {
+  return value in PROMPT_CONFIG;
+}
+
+export function getPromptFormat(promptKey: PromptKey): DiagramFormat {
+  return PROMPT_CONFIG[promptKey].format;
+}
+
+type GoogleClient = {
+  models: {
+    generateContent: (
+      request: { model: string; contents: string },
+    ) => Promise<
+      { text?: string | (() => string | Promise<string>) } & Record<string, unknown>
+    >;
+  };
+};
+
+export type ClientFactory = (apiKey: string) => GoogleClient;
+
+const defaultClientFactory: ClientFactory = (apiKey: string) =>
+  new GoogleGenAI({
+    apiKey,
+  });
+
+export async function generateAIContent(
+  promptKey: PromptKey,
+  request: Pick<AIRequestPayload, "text">,
+  apiKey: string,
+  clientFactory: ClientFactory = defaultClientFactory,
+): Promise<string> {
+  const configuration = PROMPT_CONFIG[promptKey];
+
+  if (!configuration) {
+    throw new Error(`Unknown prompt key: ${promptKey}`);
+  }
+
+  const ai = clientFactory(apiKey);
+
+  const response = await ai.models.generateContent({
+    model: MODEL_NAME,
+    contents: `
+${configuration.prompt}
+
+${request.text}`,
+  });
+
+  const rawText =
+    typeof response.text === "function" ? await response.text() : response.text;
+
+  if (typeof rawText !== "string" || rawText.trim().length === 0) {
+    throw new Error("AI response did not include text output");
+  }
+
+  return rawText;
+}

--- a/docucraft-worker/src/services/aiResponseFormatter.ts
+++ b/docucraft-worker/src/services/aiResponseFormatter.ts
@@ -1,0 +1,74 @@
+export type DiagramFormat = "mermaid" | "json";
+
+function stripCodeFence(text: string, language?: string): string {
+  let cleaned = text;
+
+  if (language) {
+    const languageFence = new RegExp("```" + language + "\\s*", "gi");
+    cleaned = cleaned.replace(languageFence, "");
+  }
+
+  return cleaned.replace(/```/g, "");
+}
+
+export function formatMermaidResponse(text: string): string {
+  return stripCodeFence(text, "mermaid").trim();
+}
+
+export function formatJsonResponse(text: string): string {
+  let cleaned = stripCodeFence(text, "json").trim();
+
+  const attemptNormalize = (value: string): string | null => {
+    try {
+      const parsed = JSON.parse(value);
+      return JSON.stringify(parsed);
+    } catch (error) {
+      return null;
+    }
+  };
+
+  let normalized = attemptNormalize(cleaned);
+
+  if (normalized) {
+    return normalized;
+  }
+
+  if (cleaned.includes("\\n") || cleaned.includes('\"')) {
+    const unescaped = cleaned
+      .replace(/\\n/g, "\n")
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, "\\");
+
+    normalized = attemptNormalize(unescaped);
+
+    if (normalized) {
+      return normalized;
+    }
+
+    cleaned = unescaped;
+  }
+
+  const reescaped = cleaned
+    .replace(/\n/g, "\\n")
+    .replace(/"/g, '\\"')
+    .replace(/\\/g, "\\\\");
+
+  normalized = attemptNormalize(reescaped);
+
+  if (!normalized) {
+    throw new Error("Unable to normalize AI JSON response");
+  }
+
+  return normalized;
+}
+
+export function formatDiagramResponse(
+  diagramFormat: DiagramFormat,
+  text: string,
+): string {
+  if (diagramFormat === "json") {
+    return formatJsonResponse(text);
+  }
+
+  return formatMermaidResponse(text);
+}

--- a/docucraft-worker/src/types.ts
+++ b/docucraft-worker/src/types.ts
@@ -12,3 +12,5 @@ export const AIRequest = z.object({
   text: Str(),
   selectedDiagrams: z.array(z.string()).optional(),
 });
+
+export type AIRequestPayload = z.infer<typeof AIRequest>;

--- a/docucraft-worker/tsconfig.json
+++ b/docucraft-worker/tsconfig.json
@@ -22,8 +22,8 @@
 		"types": [
 			"./worker-configuration.d.ts",
 			"@types/node",
-			"@types/service-worker-mock"
-		]
+                        "@types/service-worker-mock"
+                ]
 	},
 	"exclude": ["node_modules", "dist", "tests"],
 	"include": ["src", "worker-configuration.d.ts"]


### PR DESCRIPTION
## Summary
- add dedicated services for AI generation and response formatting
- refactor AI endpoints to delegate prompt selection and formatting to the new services
- add bun-based unit tests covering prompt routing and formatter behavior

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e5419262f48320b56942a8939a46ae