### PR TITLE
Refactor Stripe payment intent handling into service

### DIFF
--- a/docucraft-worker/package.json
+++ b/docucraft-worker/package.json
@@ -6,7 +6,8 @@
     "deploy": "wrangler deploy",
     "dev": "wrangler dev",
     "start": "wrangler dev",
-    "cf-typegen": "wrangler types"
+    "cf-typegen": "wrangler types",
+    "test": "bun test"
   },
   "dependencies": {
     "@google/genai": "^1.10.0",

--- a/docucraft-worker/src/services/__tests__/stripePaymentService.test.ts
+++ b/docucraft-worker/src/services/__tests__/stripePaymentService.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { createPaymentIntent } from "../stripePaymentService";
+
+describe("createPaymentIntent", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    mock.restore();
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (globalThis as Record<string, unknown>).fetch;
+    }
+    mock.restore();
+  });
+
+  it("creates a payment intent for zero-decimal currencies without scaling", async () => {
+    const mockResponse = new Response(
+      JSON.stringify({
+        id: "pi_123",
+        status: "requires_payment_method",
+      }),
+      { status: 200 }
+    );
+
+    const fetchMock = mock(() => Promise.resolve(mockResponse));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await createPaymentIntent({
+      amount: 125,
+      currency: "JPY",
+      stripeSecretKey: "sk_test",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected successful result");
+
+    const body = fetchMock.mock.calls[0][1]?.body as URLSearchParams;
+    expect(body.get("amount")).toBe("125");
+    expect(body.get("currency")).toBe("jpy");
+  });
+
+  it("scales three-decimal currencies correctly", async () => {
+    const mockResponse = new Response(
+      JSON.stringify({
+        id: "pi_456",
+        status: "requires_payment_method",
+      }),
+      { status: 200 }
+    );
+
+    const fetchMock = mock(() => Promise.resolve(mockResponse));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await createPaymentIntent({
+      amount: 10.1234,
+      currency: "KWD",
+      stripeSecretKey: "sk_test",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected successful result");
+
+    const body = fetchMock.mock.calls[0][1]?.body as URLSearchParams;
+    expect(body.get("amount")).toBe("10123");
+    expect(body.get("currency")).toBe("kwd");
+  });
+
+  it("maps Stripe error responses", async () => {
+    const mockResponse = new Response(
+      JSON.stringify({
+        error: {
+          message: "Invalid amount",
+        },
+      }),
+      { status: 400 }
+    );
+
+    const fetchMock = mock(() => Promise.resolve(mockResponse));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await createPaymentIntent({
+      amount: 20,
+      currency: "USD",
+      stripeSecretKey: "sk_test",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error result");
+    expect(result.error.type).toBe("stripe-error");
+    expect(result.error.message).toBe("Invalid amount");
+  });
+
+  it("handles unexpected Stripe responses", async () => {
+    const mockResponse = new Response(JSON.stringify({ foo: "bar" }), {
+      status: 200,
+    });
+
+    const fetchMock = mock(() => Promise.resolve(mockResponse));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await createPaymentIntent({
+      amount: 20,
+      currency: "USD",
+      stripeSecretKey: "sk_test",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error result");
+    expect(result.error.type).toBe("unexpected-response");
+  });
+
+  it("returns a missing secret key error when the key is absent", async () => {
+    const result = await createPaymentIntent({
+      amount: 20,
+      currency: "USD",
+      stripeSecretKey: undefined,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error result");
+    expect(result.error.type).toBe("missing-secret-key");
+  });
+
+  it("reports network failures as network errors", async () => {
+    const fetchMock = mock(() => Promise.reject(new Error("network down")));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await createPaymentIntent({
+      amount: 20,
+      currency: "USD",
+      stripeSecretKey: "sk_test",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("Expected error result");
+    expect(result.error.type).toBe("network-error");
+    expect(result.error.message).toBe("network down");
+  });
+});

--- a/docucraft-worker/src/services/stripePaymentService.ts
+++ b/docucraft-worker/src/services/stripePaymentService.ts
@@ -1,0 +1,166 @@
+import { z } from "zod";
+
+const PaymentIntentResponseSchema = z.object({
+  id: z.string(),
+  client_secret: z.string().optional(),
+  status: z.string(),
+});
+
+export type PaymentIntentResponse = z.infer<typeof PaymentIntentResponseSchema>;
+
+const ZERO_DECIMAL_CURRENCIES = new Set([
+  "bif",
+  "clp",
+  "djf",
+  "gnf",
+  "jpy",
+  "kmf",
+  "krw",
+  "mga",
+  "pyg",
+  "rwf",
+  "ugx",
+  "vnd",
+  "vuv",
+  "xaf",
+  "xof",
+  "xpf",
+]);
+
+const THREE_DECIMAL_CURRENCIES = new Set([
+  "bhd",
+  "jod",
+  "kwd",
+  "omr",
+  "tnd",
+]);
+
+export type CreatePaymentIntentParams = {
+  amount: number;
+  currency: string;
+  stripeSecretKey?: string | null;
+};
+
+export type CreatePaymentIntentSuccess = {
+  ok: true;
+  paymentIntent: PaymentIntentResponse;
+};
+
+export type CreatePaymentIntentError = {
+  ok: false;
+  error:
+    | { type: "missing-secret-key"; message: string }
+    | { type: "stripe-error"; message: string }
+    | { type: "unexpected-response"; message: string }
+    | { type: "network-error"; message: string };
+};
+
+export type CreatePaymentIntentResult =
+  | CreatePaymentIntentSuccess
+  | CreatePaymentIntentError;
+
+export async function createPaymentIntent({
+  amount,
+  currency,
+  stripeSecretKey,
+}: CreatePaymentIntentParams): Promise<CreatePaymentIntentResult> {
+  if (!stripeSecretKey) {
+    return {
+      ok: false,
+      error: {
+        type: "missing-secret-key",
+        message: "Stripe secret key is not configured",
+      },
+    };
+  }
+
+  const normalizedCurrency = currency.toLowerCase();
+  const currencyExponent = getCurrencyExponent(normalizedCurrency);
+  const amountInMinorUnits = toMinorCurrencyUnit(amount, currencyExponent);
+  const body = buildPaymentIntentRequestBody(amountInMinorUnits, normalizedCurrency);
+
+  try {
+    const stripeResponse = await fetch(
+      "https://api.stripe.com/v1/payment_intents",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${stripeSecretKey}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body,
+      }
+    );
+
+    const stripeData = await stripeResponse.json<unknown>();
+
+    if (!stripeResponse.ok) {
+      const errorMessage =
+        (stripeData as { error?: { message?: string } })?.error?.message ??
+        "Failed to create payment intent";
+
+      return {
+        ok: false,
+        error: {
+          type: "stripe-error",
+          message: errorMessage,
+        },
+      };
+    }
+
+    const parsedStripeData = PaymentIntentResponseSchema.safeParse(stripeData);
+
+    if (!parsedStripeData.success) {
+      return {
+        ok: false,
+        error: {
+          type: "unexpected-response",
+          message: "Unexpected Stripe response structure",
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      paymentIntent: parsedStripeData.data,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to reach Stripe to create payment intent";
+
+    return {
+      ok: false,
+      error: {
+        type: "network-error",
+        message,
+      },
+    };
+  }
+}
+
+function buildPaymentIntentRequestBody(amount: number, currency: string) {
+  const body = new URLSearchParams();
+  body.append("amount", amount.toString());
+  body.append("currency", currency);
+  body.append("automatic_payment_methods[enabled]", "true");
+  return body;
+}
+
+function getCurrencyExponent(currency: string): number {
+  if (THREE_DECIMAL_CURRENCIES.has(currency)) {
+    return 3;
+  }
+
+  if (ZERO_DECIMAL_CURRENCIES.has(currency)) {
+    return 0;
+  }
+
+  return 2;
+}
+
+function toMinorCurrencyUnit(amount: number, exponent: number): number {
+  const multiplier = 10 ** exponent;
+  return Math.round(amount * multiplier);
+}

--- a/docucraft-worker/tsconfig.json
+++ b/docucraft-worker/tsconfig.json
@@ -19,11 +19,11 @@
 		"module": "es2022",
 		"noEmit": true,
 		"lib": ["es2022"],
-		"types": [
-			"./worker-configuration.d.ts",
-			"@types/node",
-			"@types/service-worker-mock"
-		]
+                "types": [
+                        "./worker-configuration.d.ts",
+                        "@types/node",
+                        "@types/service-worker-mock"
+                ]
 	},
 	"exclude": ["node_modules", "dist", "tests"],
 	"include": ["src", "worker-configuration.d.ts"]


### PR DESCRIPTION
## Summary
- extract Stripe payment intent logic into a dedicated service with currency helpers and typed results
- update the create payment intent endpoint to consume the service and translate results into HTTP responses
- add bun-based unit tests covering currency conversion, error handling, and success cases

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e54192ccb08320b567c213726eaff7